### PR TITLE
feat(src): support TypeApplication like `Array.<string>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ Easy to use it with Babel.
 
 - [azu/babel-plugin-jsdoc-to-assert: Babel plugin for jsdoc-to-assert.](https://github.com/azu/babel-plugin-jsdoc-to-assert "azu/babel-plugin-jsdoc-to-assert: Babel plugin for jsdoc-to-assert.")
 
+## Example
+
+jsdoc-to-assert create detection expression string:
+
+```js
+Array.isArray(x) && x.every(function (item) {
+    return typeof item === 'number';
+});
+``` 
+
+from following JSDoc comment:
+
+```js
+/**
+ * @param {number[]} x 
+ */
+```
+
 ## Installation
 
     npm install jsdoc-to-assert
@@ -15,7 +33,6 @@ Easy to use it with Babel.
 ```js
 import {AssertGenerator, CommentConverter, CodeGenerator} from "jsdoc-to-assert";
 ```
-
 
 ### AssertGenerator class
 

--- a/src/tag/Expression.js
+++ b/src/tag/Expression.js
@@ -16,9 +16,13 @@ export function Expression(tagName, typeValue) {
         const expectedType = typeofName(typeValue.name);
         if (expectedType == null) {
             const expectedName = typeValue.name;
-            // if right-hand is undefined, return true
+            // if right-hand(expectedName) is undefined, return true
             // if right-hand is not function, return true
-            // if right-hand is function && left instanceof right
+            // if right-hand is function && left-hand(tagName) instanceof right-hand(expectedName)
+            // expectation, if left-hand is Array, use Array.isArray
+            if (expectedName === "Array") {
+                return `Array.isArray(${tagName})`;
+            }
             return `(
                 typeof ${expectedName} === "undefined" || typeof ${expectedName} !== "function" || ${tagName} instanceof ${expectedName}
              )`;

--- a/src/tag/TypeApplication.js
+++ b/src/tag/TypeApplication.js
@@ -1,12 +1,29 @@
 // LICENSE : MIT
 "use strict";
-// @param {Array<string>}
+import {Expression} from "./Expression";
+// @param {Array.<string>}
 /**
  * @return {string|undefined}
  */
 export function TypeApplication(tag, CodeGenerator) {
     const expectedType = tag.type.expression.name;
     if (expectedType === "Array") {
-        return CodeGenerator.assert(`Array.isArray(${tag.name})`);
+        const applications = tag.type.applications;
+        if (applications) {
+            const createGenericsAssert = () => {
+                // or
+                const expressions = applications.map(application => {
+                    return Expression("item", application);
+                });
+                // Array.<String,Number>
+                // => (String || Number)
+                const expression = expressions.join(" || ");
+                return `function(item){ return (${expression}); }`;
+            };
+            const expression = `${tag.name}.every(${createGenericsAssert()})`;
+            return CodeGenerator.assert(`Array.isArray(${tag.name}) && ${expression}`);
+        } else {
+            return CodeGenerator.assert(`Array.isArray(${tag.name})`);
+        }
     }
 }

--- a/test/create-asserts-test.js
+++ b/test/create-asserts-test.js
@@ -182,16 +182,48 @@ describe("create-assert", function() {
             astEqual(numberAssertion, `typeof A === 'undefined' || typeof A !== 'function' || x instanceof A`);
         });
     });
-    context("when pass ArrayType", function() {
-        it("should return assert typeof nullable", function() {
+    context("when pass Array only", function() {
+        it("should return Array.isArray(x)", function() {
             const jsdoc = `/**
- * @param {number[]} x - this is ArrayType param.
+ * @param {Array} x - this is ArrayType param.
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `Array.isArray(x)`);
         });
     });
-
+    context("when pass *[]", function() {
+        it("should return Array.isArray(x)", function() {
+            const jsdoc = `/**
+ * @param {*[]} x
+ */`;
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
+    return typeof undefined === 'undefined' || typeof undefined !== 'function' || item instanceof undefined;
+});`);
+        });
+    });
+    context("when pass number[]", function() {
+        it("should return Array.isArray(array) && check every type", function() {
+            const jsdoc = `/**
+ * @param {number[]} x - this is ArrayType param.
+ */`;
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
+    return typeof item === 'number';
+});`);
+        });
+    });
+    context("when pass CustomType[]", function() {
+        it("should return Array.isArray(array) && check every type", function() {
+            const jsdoc = `/**
+ * @param {CustomType[]} x - this is ArrayType param.
+ */`;
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
+    return typeof CustomType === 'undefined' || typeof CustomType !== 'function' || item instanceof CustomType;
+});`);
+        });
+    });
     context("when pass nullable", function() {
         it("should return assert typeof nullable", function() {
             const jsdoc = `/**
@@ -262,13 +294,15 @@ describe("create-assert", function() {
             astEqual(numberAssertion, `typeof x.foo === 'number' && (typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x.bar instanceof RegExp)`);
         });
     });
-    context("When generic", function() {
-        it("should return ", function() {
+    context("When pass Array.<string>", function() {
+        it("should return Array.isArray(x) && check every type", function() {
             const jsdoc = `/**
- * @param {Array<string>} x - this is Array param.
+ * @param {Array.<string>} x - this is Array param.
  */`;
             const numberAssertion = createAssertion(jsdoc);
-            astEqual(numberAssertion, `Array.isArray(x);`);
+            astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
+    return typeof item === 'string';
+});`);
         });
     });
 });


### PR DESCRIPTION
``` js
/**
 * @param {number[]} x 
 */
```

to be

``` js
Array.isArray(x) && x.every(function (item) {
    return typeof item === 'number';
});
```

`Array.<string>` or `string[]` or `Array<string>`
- http://usejsdoc.org/tags-type.html
- https://developers.google.com/closure/compiler/docs/js-for-compiler#types
## Related

close https://github.com/azu/jsdoc-to-assert/issues/2
