### PR TITLE
fix(Expression): should ignore {obj.prop} type

### DIFF
--- a/src/tag/Expression.js
+++ b/src/tag/Expression.js
@@ -16,6 +16,10 @@ export function Expression(tagName, typeValue) {
         const expectedType = typeofName(typeValue.name);
         if (expectedType == null) {
             const expectedName = typeValue.name;
+            // Can not handle Object.Property type like @param {Custom.Type}
+            if (/\w+\.\w+/.test(expectedName)) {
+                return "true";
+            }
             // if right-hand(expectedName) is undefined, return true
             // if right-hand is not function, return true
             // if right-hand is function && left-hand(tagName) instanceof right-hand(expectedName)

--- a/test/create-asserts-test.js
+++ b/test/create-asserts-test.js
@@ -182,6 +182,16 @@ describe("create-assert", function() {
             astEqual(numberAssertion, `typeof CustomType === 'undefined' || typeof CustomType !== 'function' || x instanceof CustomType`);
         });
     });
+    context("when pass Object.Property type", function() {
+        it("should return assert typeof nullable", function() {
+            const A = {};
+            const jsdoc = `/**
+ * @param {Object.Property} x - this is ArrayType param.
+ */`;
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, "true");
+        });
+    });
     context("when pass Array only", function() {
         it("should return Array.isArray(x)", function() {
             const jsdoc = `/**


### PR DESCRIPTION
We can not handle obj.prop type like `@param {My.Type}`

close #4
