### PR TITLE
feat(tag): support Symbol.hasInstance

### DIFF
--- a/src/tag/Expression.js
+++ b/src/tag/Expression.js
@@ -28,7 +28,7 @@ export function Expression(tagName, typeValue) {
                 return `Array.isArray(${tagName})`;
             }
             return `(
-                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!${expectedName} && typeof ${expectedName}[Symbol.hasInstance] === "function" ?
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof ${expectedName} !== "undefined" && typeof ${expectedName}[Symbol.hasInstance] === "function" ?
                 ${expectedName}[Symbol.hasInstance](${tagName}) :
                 typeof ${expectedName} === "undefined" || typeof ${expectedName} !== "function" || ${tagName} instanceof ${expectedName}
             )`;

--- a/src/tag/Expression.js
+++ b/src/tag/Expression.js
@@ -28,8 +28,10 @@ export function Expression(tagName, typeValue) {
                 return `Array.isArray(${tagName})`;
             }
             return `(
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!${expectedName} && typeof ${expectedName}[Symbol.hasInstance] === "function" ?
+                ${expectedName}[Symbol.hasInstance](${tagName}) :
                 typeof ${expectedName} === "undefined" || typeof ${expectedName} !== "function" || ${tagName} instanceof ${expectedName}
-             )`;
+            )`;
         } else {
             return `typeof ${tagName} === "${expectedType}"`;
         }

--- a/test/create-asserts-test.js
+++ b/test/create-asserts-test.js
@@ -169,7 +169,11 @@ describe("create-assert", function() {
  * @param {RegExp} x - this is RegExp.
  */`;
             const assertion = createAssertion(jsdoc);
-            astEqual(assertion, `typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x instanceof RegExp`);
+            astEqual(assertion, `
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!RegExp && typeof RegExp[Symbol.hasInstance] === "function" ?
+                RegExp[Symbol.hasInstance](x) :
+                typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x instanceof RegExp
+            `);
         });
     });
     context("when pass Custom Object", function() {
@@ -179,7 +183,11 @@ describe("create-assert", function() {
  * @param {CustomType} x - this is ArrayType param.
  */`;
             const numberAssertion = createAssertion(jsdoc);
-            astEqual(numberAssertion, `typeof CustomType === 'undefined' || typeof CustomType !== 'function' || x instanceof CustomType`);
+            astEqual(numberAssertion, `
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+                CustomType[Symbol.hasInstance](x) :
+                typeof CustomType === 'undefined' || typeof CustomType !== 'function' || x instanceof CustomType
+            `);
         });
     });
     context("when pass Object.Property type", function() {
@@ -208,7 +216,9 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
-    return typeof undefined === 'undefined' || typeof undefined !== 'function' || item instanceof undefined;
+    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!undefined && typeof undefined[Symbol.hasInstance] === "function" ?
+        undefined[Symbol.hasInstance](item) :
+        typeof undefined === 'undefined' || typeof undefined !== 'function' || item instanceof undefined;
 });`);
         });
     });
@@ -230,7 +240,9 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
-    return typeof CustomType === 'undefined' || typeof CustomType !== 'function' || item instanceof CustomType;
+    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+        CustomType[Symbol.hasInstance](item) :
+        typeof CustomType === 'undefined' || typeof CustomType !== 'function' || item instanceof CustomType;
 });`);
         });
     });
@@ -307,7 +319,12 @@ describe("create-assert", function() {
  * @param {{foo: number, bar: RegExp}} x - this is object param.
  */`;
             const numberAssertion = createAssertion(jsdoc);
-            astEqual(numberAssertion, `typeof x.foo === 'number' && (typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x.bar instanceof RegExp)`);
+            astEqual(numberAssertion, `typeof x.foo === 'number' && (
+                  typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!RegExp && typeof RegExp[Symbol.hasInstance] === "function" ?
+                  RegExp[Symbol.hasInstance](x.bar) :
+                  typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x.bar instanceof RegExp
+                )
+            `);
         });
     });
     context("When pass Array.<string>", function() {

--- a/test/create-asserts-test.js
+++ b/test/create-asserts-test.js
@@ -170,7 +170,7 @@ describe("create-assert", function() {
  */`;
             const assertion = createAssertion(jsdoc);
             astEqual(assertion, `
-                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!RegExp && typeof RegExp[Symbol.hasInstance] === "function" ?
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof RegExp !== "undefined" && typeof RegExp[Symbol.hasInstance] === "function" ?
                 RegExp[Symbol.hasInstance](x) :
                 typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x instanceof RegExp
             `);
@@ -184,7 +184,7 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `
-                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+                typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof CustomType !== "undefined" && typeof CustomType[Symbol.hasInstance] === "function" ?
                 CustomType[Symbol.hasInstance](x) :
                 typeof CustomType === 'undefined' || typeof CustomType !== 'function' || x instanceof CustomType
             `);
@@ -216,7 +216,7 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
-    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!undefined && typeof undefined[Symbol.hasInstance] === "function" ?
+    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof undefined !== "undefined" && typeof undefined[Symbol.hasInstance] === "function" ?
         undefined[Symbol.hasInstance](item) :
         typeof undefined === 'undefined' || typeof undefined !== 'function' || item instanceof undefined;
 });`);
@@ -240,7 +240,7 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
-    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+    return typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof CustomType !== "undefined" && typeof CustomType[Symbol.hasInstance] === "function" ?
         CustomType[Symbol.hasInstance](item) :
         typeof CustomType === 'undefined' || typeof CustomType !== 'function' || item instanceof CustomType;
 });`);
@@ -320,7 +320,7 @@ describe("create-assert", function() {
  */`;
             const numberAssertion = createAssertion(jsdoc);
             astEqual(numberAssertion, `typeof x.foo === 'number' && (
-                  typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!RegExp && typeof RegExp[Symbol.hasInstance] === "function" ?
+                  typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof RegExp !== "undefined" && typeof RegExp[Symbol.hasInstance] === "function" ?
                   RegExp[Symbol.hasInstance](x.bar) :
                   typeof RegExp === 'undefined' || typeof RegExp !== 'function' || x.bar instanceof RegExp
                 )

--- a/test/hasInstance-test.js
+++ b/test/hasInstance-test.js
@@ -1,0 +1,55 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+
+const notUse_hasInstance = {};
+
+function createCustomTypeAssertFunction(CustomType) {
+    return function(value) {
+        return (
+          typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+          CustomType[Symbol.hasInstance](value) :
+          notUse_hasInstance
+        );
+    };
+}
+
+describe("hasInstance", function() {
+    if (typeof Symbol !== "function" || typeof Symbol.hasInstance !== "symbol") {
+        it.skip("Symbol.hasInstance is not supported in this environment", function() {});
+        return;
+    }
+
+    context("class", function() {
+        it("should work same as 'instanceof CustomType'", function() {
+            class CustomType {}
+
+            const assertFunc = createCustomTypeAssertFunction(CustomType);
+
+            assert(assertFunc(new CustomType()) === true);
+            assert(assertFunc(new Int8Array(0)) === false);
+        });
+    });
+    context("object with [Symbol.hasInstance]", function() {
+        it("should return [Symbol.hasInstance]() value", function() {
+            const EvenNumber = {
+                [Symbol.hasInstance](value) {
+                    return value % 2 === 0;
+                }
+            };
+
+            const assertFunc = createCustomTypeAssertFunction(EvenNumber);
+
+            assert(assertFunc(100) === true);
+            assert(assertFunc(101) === false);
+        });
+    });
+    context("object without [Symbol.hasInstance]", function() {
+        it("should not use [Symbol.hasInstance]()", function() {
+            const assertFunc = createCustomTypeAssertFunction(null);
+
+            assert(assertFunc(100) === notUse_hasInstance);
+            assert(assertFunc(200) === notUse_hasInstance);
+        });
+    });
+});

--- a/test/hasInstance-test.js
+++ b/test/hasInstance-test.js
@@ -7,7 +7,7 @@ const notUse_hasInstance = {};
 function createCustomTypeAssertFunction(CustomType) {
     return function(value) {
         return (
-          typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!CustomType && typeof CustomType[Symbol.hasInstance] === "function" ?
+          typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && typeof CustomType !== "undefined" && typeof CustomType[Symbol.hasInstance] === "function" ?
           CustomType[Symbol.hasInstance](value) :
           notUse_hasInstance
         );
@@ -46,7 +46,7 @@ describe("hasInstance", function() {
     });
     context("object without [Symbol.hasInstance]", function() {
         it("should not use [Symbol.hasInstance]()", function() {
-            const assertFunc = createCustomTypeAssertFunction(null);
+            const assertFunc = createCustomTypeAssertFunction({});
 
             assert(assertFunc(100) === notUse_hasInstance);
             assert(assertFunc(200) === notUse_hasInstance);


### PR DESCRIPTION
In Node.js 6.5 or later (maybe V8 5.1), 
We can use [`Symbol.hasInstance`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) to determine object types.

```js
const EvenNumber = {
  [Symbol.hasInstance](value) {
    return value % 2 === 0;
  }
};

12 instanceof EvenNumber; // true
13 instanceof EvenNumber; // false
```


but `jsdoc-to-assert` is not supported it.

```js
/**
 * @param {EvenNumber} value
 */
function half(value) {
  return value / 2;
}

console.log(half(13)); // provide odd number, but it pass
```

This PR aims to support the object value detection using `Symbol.hasInstance`, in Node.js **v6.0** or later.
(In Node.js 6.0 (V8 5.0), `Symbol.hasInstance` is exists, but does not work `value instanceof CustomType`)

---

replace src/tag/Expression.js

before
```js
`(
    typeof ${expectedName} === "undefined" || typeof ${expectedName} !== "function" || ${tagName} instanceof ${expectedName}
)`
```

after
```js
`(
    typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol" && !!${expectedName} && typeof ${expectedName}[Symbol.hasInstance] === "function" ?
    ${expectedName}[Symbol.hasInstance](${tagName}) :
    typeof ${expectedName} === "undefined" || typeof ${expectedName} !== "function" || ${tagName} instanceof ${expectedName}
)`
```

