### PR TITLE
fix(tag): fix anonymous Record Type.

### DIFF
--- a/src/tag/Expression.js
+++ b/src/tag/Expression.js
@@ -4,6 +4,11 @@
  * @return {string}
  */
 export function Expression(tagName, typeValue) {
+    // https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#record-type
+    // > myObject that has a value of **any** type.
+    if (typeValue === null) {
+        return `typeof ${tagName} !== "undefined"`;
+    }
     if (typeValue.type && typeValue.type === "NullableType") {
         // recursion
         const otherExpression = Expression(tagName, typeValue.expression);

--- a/src/tag/RecordType.js
+++ b/src/tag/RecordType.js
@@ -1,6 +1,7 @@
 // LICENSE : MIT
 "use strict";
 //  * @param {{foo: ?number, bar: string}} x - this is object param.
+//  * @param {{foo, bar}} x - this is object param.
 import {Expression} from "./Expression";
 /**
  * @return {string}

--- a/test/create-asserts-test.js
+++ b/test/create-asserts-test.js
@@ -286,20 +286,27 @@ describe("create-assert", function() {
             astEqual(numberAssertion, `(typeof x === "number" || typeof x === "string")`);
         });
     });
-       context("when pass ...number", function () {
-           it("should return Array.isArray(param) && check every type", function () {
-               const jsdoc = `
+    context("when pass ...number", function() {
+        it("should return Array.isArray(param) && check every type", function() {
+            const jsdoc = `
 /**
  * @param {...number} x - this is spread param.
  */`;
 
-               const numberAssertion = createAssertion(jsdoc);
-               astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, `Array.isArray(x) && x.every(function (item) {
     return typeof item === 'number';
 })`);
-           });
-       });
+        });
+    });
     context("when pass RecordType", function() {
+        it("should assert multiple types ", function() {
+            const jsdoc = `/**
+* @param {{SubscriptionId,Data}} data
+*/`;
+            const numberAssertion = createAssertion(jsdoc);
+            astEqual(numberAssertion, `typeof data.SubscriptionId !== 'undefined' && typeof data.Data !== 'undefined';`);
+        });
         it("should assert foo.bar as NullableType ", function() {
             const jsdoc = `/**
  * @param {{foo: ?number, bar: string}} x - this is object param.


### PR DESCRIPTION
```js
        /**
         * @param {{SubscriptionId,Data}} data
         */
```

It should be follwoing assertion:

```js
typeof data.SubscriptionId !== 'undefined' && typeof data.Data !== 'undefined';
```

Docs:

> Example: {myNum: number, myObject}
> An anonymous type with both a property named myNum that has a value of type number and a property named myObject that has a value of any type.
> -- https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#record-type


close #9